### PR TITLE
Make it possible to unbind

### DIFF
--- a/mediawiki:latest/Dockerfile-dev
+++ b/mediawiki:latest/Dockerfile-dev
@@ -6,6 +6,8 @@ ENV USER_NAME=www-data \
     PHP=71 \
     HOME=${BASE_DIR}
 
+COPY mediawiki.conf /usr/share/mediawiki-container-scripts/mediawiki.conf.example
+
 RUN curl https://copr.fedorainfracloud.org/coprs/g/ansible-service-broker/ansible-service-broker-latest/repo/epel-7/group_ansible-service-broker-ansible-service-broker-latest-epel-7.repo -o /etc/yum.repos.d/asb.repo \
     && yum -y update \
     && yum -y install epel-release \
@@ -42,7 +44,6 @@ RUN curl https://copr.fedorainfracloud.org/coprs/g/ansible-service-broker/ansibl
     && sed "s@${USER_NAME}:x:${USER_UID}:@${USER_NAME}:x:\${USER_ID}:@g" /etc/passwd > ${BASE_DIR}/etc/passwd.template
 
 COPY entrypoint.sh /usr/bin/
-COPY mediawiki.conf /usr/share/mediawiki-container-scripts/mediawiki.conf.example
 
 EXPOSE 8080
 USER ${USER_UID}

--- a/mediawiki:latest/entrypoint.sh
+++ b/mediawiki:latest/entrypoint.sh
@@ -20,9 +20,11 @@ fi
 LOCAL_SETTINGS=${BASE_DIR}/httpd/mediawiki/LocalSettings.php
 IMAGE_DIR=${BASE_DIR}/httpd/mediawiki/images
 if [ -d "$MEDIAWIKI_SHARED" ]; then
-  if [ ! -e "$MEDIAWIKI_SHARED/LocalSettings.php" ] && [ ! -z "${DB_HOST}" ]; then
-    # If the container is restarted this will fail because the tables are already created
-    # but there won't be a LocalSettings.php
+  if [ -e "$MEDIAWIKI_SHARED/LocalSettings.php" ] && [ -z "${DB_HOST}" ]; then
+    #In the Unbind scenario the LocalSettings.php exists but the DB_HOST env var does not.
+    rm -f "$MEDIAWIKI_SHARED/LocalSettings.php"
+  elif [ ! -e "$MEDIAWIKI_SHARED/LocalSettings.php" ] && [ ! -z "${DB_HOST}" ]; then
+    #In the Bind scenario the LocalSettings.php does not exist but the DB_HOST env var does.
     scl enable rh-php${PHP} "php /usr/share/mediawiki/maintenance/install.php \
       --confpath ${BASE_DIR}/httpd/mediawiki \
       --dbname \"$DB_NAME\" \


### PR DESCRIPTION
N.B., It is not possible to rebind to a database that has been previously bound to. The mediawiki install script does not support recreating the database tables in the case it has already been created. We could probably drop them ahead of time, but that's probably unwise to do as it could cause unintentional data loss.